### PR TITLE
added autoload-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "P1ho\\AccessibilityChecker\\": "/src",
+            "P1ho\\AccessibilityChecker\\": "/src"
         },
         "classmap": [
             "src/ColorContrast/Checker.php",
@@ -46,7 +46,7 @@
             "src/LinkAccessibility/Base.php",
             "src/LinkAccessibility/Checker.php",
             "src/LinkAccessibility/LinkQuality/Checker.php",
-            "src/LinkAccessibility/LinkText/Checker.php",
+            "src/LinkAccessibility/LinkText/Checker.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "autoload": {
         "psr-4": {
             "P1ho\\AccessibilityChecker\\": "/src",
-            "P1ho\\AccessibilityChecker\\Tests\\": "/tests"
         },
         "classmap": [
             "src/ColorContrast/Checker.php",
@@ -48,6 +47,13 @@
             "src/LinkAccessibility/Checker.php",
             "src/LinkAccessibility/LinkQuality/Checker.php",
             "src/LinkAccessibility/LinkText/Checker.php",
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "P1ho\\AccessibilityChecker\\Tests\\": "/tests"
+        },
+        "classmap": [
             "tests/ColorContrast/CheckerTest.php",
             "tests/ColorContrast/CalculatorTest.php",
             "tests/HeadingStructure/CheckerTest.php",


### PR DESCRIPTION
Hi,

on composer.json the autoload-dev section was missing. I needed it for compiling a phar file.